### PR TITLE
add <meta charset="utf-8"> to HTML page

### DIFF
--- a/template.hbs
+++ b/template.hbs
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta charset="utf-8">
     <title>HTML Validation Report</title>
     <style>
       body {font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, “Fira Sans”, “Droid Sans”, "Helvetica Neue", Arial, sans-serif;}


### PR DESCRIPTION
The contents of the generated HTML page is utf8 but without this tag it is rendered with default char set.